### PR TITLE
Removed support for custom animation

### DIFF
--- a/Pilot.xcodeproj/project.pbxproj
+++ b/Pilot.xcodeproj/project.pbxproj
@@ -151,7 +151,7 @@
 		DBC7C5D5142D6A86003289ED /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		DBC7C5D7142D6A86003289ED /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		DBC7C5D9142D6A86003289ED /* PilotTabbarTestApp-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PilotTabbarTestApp-Prefix.pch"; sourceTree = "<group>"; };
-		DBC7C5DA142D6A86003289ED /* AppDelegate.h */ = {isa = PBXFileReference; name = AppDelegate.h; path = Classes/AppDelegate.h; sourceTree = "<group>"; };
+		DBC7C5DA142D6A86003289ED /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = Classes/AppDelegate.h; sourceTree = "<group>"; };
 		DBC7C5DB142D6A86003289ED /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = Classes/AppDelegate.m; sourceTree = "<group>"; };
 		DBC7C615142D6D0B003289ED /* first.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = first.png; path = Classes/first.png; sourceTree = "<group>"; };
 		DBC7C616142D6D0B003289ED /* first@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "first@2x.png"; path = "Classes/first@2x.png"; sourceTree = "<group>"; };

--- a/Pilot.xcodeproj/project.pbxproj
+++ b/Pilot.xcodeproj/project.pbxproj
@@ -151,7 +151,7 @@
 		DBC7C5D5142D6A86003289ED /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		DBC7C5D7142D6A86003289ED /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		DBC7C5D9142D6A86003289ED /* PilotTabbarTestApp-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PilotTabbarTestApp-Prefix.pch"; sourceTree = "<group>"; };
-		DBC7C5DA142D6A86003289ED /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = Classes/AppDelegate.h; sourceTree = "<group>"; };
+		DBC7C5DA142D6A86003289ED /* AppDelegate.h */ = {isa = PBXFileReference; name = AppDelegate.h; path = Classes/AppDelegate.h; sourceTree = "<group>"; };
 		DBC7C5DB142D6A86003289ED /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = Classes/AppDelegate.m; sourceTree = "<group>"; };
 		DBC7C615142D6D0B003289ED /* first.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = first.png; path = Classes/first.png; sourceTree = "<group>"; };
 		DBC7C616142D6D0B003289ED /* first@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "first@2x.png"; path = "Classes/first@2x.png"; sourceTree = "<group>"; };

--- a/Pilot/Pilot.h
+++ b/Pilot/Pilot.h
@@ -10,19 +10,44 @@
 #import <UIKit/UIKit.h>
 #import <CoreData/CoreData.h>
 
-
-
 @interface Pilot : NSObject
 
 /**
- *
+ Setup Pilot to use the input navigation controller for all navigation.  Usually
+ You would build the navigation controller in your AppDelegat.  See the PilotTestApp
+ for more details.
+ 
+ @params navigationController This will be used as the app-wide navigation controller
  */
 + (void)setupWithNavigationController:(UINavigationController *)navigationController;
 
-/**
- *
- */
 + (void)setupWithTabBarController:(UITabBarController *)tabBarController;
+
++ (void)pushViewController:(id)viewController animated:(BOOL)animated;
+
++ (void)presentViewControllerAsModal:(id)viewController animated:(BOOL)animated;
+
+/**
+ Pops the top view controller off the stack
+ */
++ (void)popTopViewControllerAnimated:(BOOL)animated;
+
+/**
+ Returns the view controller class for the given NSManagedObject.  This follows
+ a naming convention of "<Object Class Name>ViewController".
+ */
++ (Class)viewControllerClassForObject:(NSManagedObject *)object;
+
+/**
+ The default initializer on the View Controller to be presented
+ */
++ (SEL)defaultInitializer;
+
+/**
+ Returns the current navigation controller.  If using a Tabbar app, this will
+ return the current selected view controller
+ */
++ (UINavigationController *)currentNavigationController;
 
 /**
  * Reset Pilot to a clean state.
@@ -34,51 +59,26 @@
  */
 + (void)showObject:(NSManagedObject *)object;
 
++ (void)showObject:(NSManagedObject *)object animated:(BOOL)animated;
+
++ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector;
+
++ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector animated:(BOOL)animated;
+
 /**
- *
+ Pushes the objects view controller onto the stack as a modal ViewController
  */
 + (void)showObjectAsModal:(NSManagedObject *)object;
 
-/**
- *
- */
-+ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector;
++ (void)showObjectAsModal:(NSManagedObject *)object animated:(BOOL)animated;
 
-/**
- *
- */
 + (void)showObjectAsModal:(NSManagedObject *)object withSelector:(SEL)selector;
 
-/**
- *
- */
-+ (void)showObject:(NSManagedObject *)object animation:(UIViewAnimationTransition)animation;
++ (void)showObjectAsModal:(NSManagedObject *)object withSelector:(SEL)selector animated:(BOOL)animated;
 
 /**
- Pushes the objects view controller onto the stack with the given animation transition
- over the given duration.
+ All "show" actions filter down to this method
  */
-+ (void)showObject:(NSManagedObject *)object animation:(UIViewAnimationTransition)animation duration:(CGFloat)duration;
-
-/**
- *
- */
-+ (void)showObjectAsModal:(NSManagedObject *)object animation:(UIViewAnimationTransition)animation;
-
-/**
- *
- */
-+ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector animation:(UIViewAnimationTransition)animation duration:(CGFloat)duration;
-
-/**
- *
- */
-+ (void)showObjectAsModal:(NSManagedObject *)object withSelector:(SEL)selector animation:(UIViewAnimationTransition)animation;
-
-/**
- Pushes the objects view controller onto the stack with the given animation transition
- over the given duration, and performs the designated selector.
- */
-+ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector animation:(UIViewAnimationTransition)animation duration:(CGFloat)duration asModal:(BOOL)asModal;
++ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector animated:(BOOL)animated asModal:(BOOL)asModal;
 
 @end

--- a/Pilot/Pilot.m
+++ b/Pilot/Pilot.m
@@ -35,8 +35,8 @@ static UITabBarController *rootTabBarController = nil;
                                                   animated:animation];
 }
 
-+ (void)presentViewControllerAsModal:(id)viewController animated:(BOOL)animation {
-    [[self currentNavigationController] presentModalViewController:viewController animated:animation];
++ (void)presentViewControllerAsModal:(id)viewController animated:(BOOL)animated {
+    [[self currentNavigationController] presentModalViewController:viewController animated:animated];
 }
 
 + (void)popTopViewControllerAnimated:(BOOL)animated {

--- a/Pilot/Pilot.m
+++ b/Pilot/Pilot.m
@@ -8,22 +8,61 @@
 
 #import "Pilot.h"
 
-#define PILOT_ANIMATION_DURATION 0.3
-
-@interface Pilot (Private)
-+ (Class)viewControllerClassForObject:(NSManagedObject *)object;
-+ (SEL)defaultInitializer;
-+ (void)presentViewController:(id)viewController withAnimation:(UIViewAnimationTransition)animation;
-+ (void)presentViewControllerAsModal:(id)viewController withAnimation:(UIViewAnimationTransition)animation;
-+ (UINavigationController *)currentNavigationController;
-@end
-
 static UINavigationController *rootNavigationController = nil;
 static UITabBarController *rootTabBarController = nil;
 
 @implementation Pilot
 
-#pragma mark - Private Methods
+#pragma mark - Setup
+
++ (void)setupWithNavigationController:(UINavigationController *)navigationController {
+    rootNavigationController = navigationController;
+}
+
++ (void)setupWithTabBarController:(UITabBarController *)tabBarController {
+    rootTabBarController = tabBarController;
+}
+
++ (void)reset {
+    rootNavigationController = nil;
+    rootTabBarController = nil;
+}
+
+#pragma mark - Navigation
+
++ (void)pushViewController:(id)viewController animated:(BOOL)animation {
+    [[self currentNavigationController] pushViewController:viewController 
+                                                  animated:animation];
+}
+
++ (void)presentViewControllerAsModal:(id)viewController animated:(BOOL)animation {
+    [[self currentNavigationController] presentModalViewController:viewController animated:animation];
+}
+
++ (void)popTopViewControllerAnimated:(BOOL)animated {
+    [[self currentNavigationController] popViewControllerAnimated:animated];
+}
+
+// TODO: Custom animations
+//+ (void)pushViewController:(id)viewController 
+//       withCustomAnimation:(UIViewAnimationTransition)animation 
+//               andDuration:(CGFloat)duration {
+//    
+//    if (animation != UIViewAnimationOptionTransitionNone) {
+//        [UIView transitionWithView:[self currentNavigationController].view 
+//                          duration:duration
+//                           options:animation
+//                        animations:^{ 
+//                            [[self currentNavigationController] pushViewController:viewController 
+//                                                                          animated:NO];
+//                        }
+//                        completion:NULL];
+//    } else {
+//        [self pushViewController:viewController animated:NO];
+//    }
+//}
+
+#pragma mark - 
 
 + (Class)viewControllerClassForObject:(NSManagedObject *)object {
     
@@ -43,26 +82,6 @@ static UITabBarController *rootTabBarController = nil;
     return NSSelectorFromString(@"initWithObjectURI:");
 }
 
-+ (void)presentViewController:(id)viewController withAnimation:(UIViewAnimationTransition)animation andDuration:(CGFloat)duration {
-    
-    if (animation != UIViewAnimationOptionTransitionNone) {
-        [UIView transitionWithView:[self currentNavigationController].view 
-                          duration:duration
-                           options:animation
-                        animations:^{ 
-                            [[self currentNavigationController] pushViewController:viewController 
-                                                                          animated:NO];
-                        }
-                        completion:NULL];
-    } else {
-        [[self currentNavigationController] pushViewController:viewController animated:YES];        
-    }
-}
-
-+ (void)presentViewControllerAsModal:(id)viewController withAnimation:(UIViewAnimationTransition)animation {
-    [[self currentNavigationController] presentModalViewController:viewController animated:YES];
-}
-
 + (UINavigationController *)currentNavigationController {
     if (rootNavigationController) {
         return rootNavigationController;
@@ -77,58 +96,41 @@ static UITabBarController *rootTabBarController = nil;
     return nil;
 }
 
-#pragma mark - Public API
-
-+ (void)setupWithNavigationController:(UINavigationController *)navigationController {
-    rootNavigationController = navigationController;
-}
-
-+ (void)setupWithTabBarController:(UITabBarController *)tabBarController {
-    rootTabBarController = tabBarController;
-}
-
-+ (void)reset {
-    rootNavigationController = nil;
-    rootTabBarController = nil;
-}
+#pragma mark - Show
 
 + (void)showObject:(NSManagedObject *)object {
-    [self showObject:object withSelector:[self defaultInitializer] animation:UIViewAnimationTransitionNone duration:PILOT_ANIMATION_DURATION asModal:NO];
-}
-
-+ (void)showObjectAsModal:(NSManagedObject *)object {
-    [self showObject:object withSelector:[self defaultInitializer] animation:UIViewAnimationTransitionNone duration:PILOT_ANIMATION_DURATION asModal:YES];
+    [self showObject:object withSelector:[self defaultInitializer] animated:YES asModal:NO];
 }
 
 + (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector {
-    [self showObject:object withSelector:selector animation:UIViewAnimationTransitionNone duration:PILOT_ANIMATION_DURATION asModal:NO];
+    [self showObject:object withSelector:selector animated:YES asModal:NO];
+}
+
++ (void)showObject:(NSManagedObject *)object animated:(BOOL)animated {
+    [self showObject:object withSelector:[self defaultInitializer] animated:animated asModal:NO];
+}
+
++ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector animated:(BOOL)animated {
+    [self showObject:object withSelector:selector animated:animated asModal:NO];
+}
+
++ (void)showObjectAsModal:(NSManagedObject *)object {    
+    [self showObject:object withSelector:[self defaultInitializer] animated:YES asModal:YES];
 }
 
 + (void)showObjectAsModal:(NSManagedObject *)object withSelector:(SEL)selector {
-    [self showObject:object withSelector:selector animation:UIViewAnimationTransitionNone duration:PILOT_ANIMATION_DURATION asModal:YES];
+    [self showObject:object withSelector:selector animated:YES asModal:YES];
 }
 
-+ (void)showObject:(NSManagedObject *)object animation:(UIViewAnimationTransition)animation {
-    [self showObject:object withSelector:[self defaultInitializer] animation:animation duration:PILOT_ANIMATION_DURATION asModal:NO];
++ (void)showObjectAsModal:(NSManagedObject *)object animated:(BOOL)animated {
+    [self showObject:object withSelector:[self defaultInitializer] animated:animated asModal:YES];
 }
 
-+ (void)showObject:(NSManagedObject *)object animation:(UIViewAnimationTransition)animation duration:(CGFloat)duration {
-    [self showObject:object withSelector:[self defaultInitializer] animation:animation duration:duration asModal:NO];
++ (void)showObjectAsModal:(NSManagedObject *)object withSelector:(SEL)selector animated:(BOOL)animated {
+    [self showObject:object withSelector:selector animated:animated asModal:YES];
 }
 
-+ (void)showObjectAsModal:(NSManagedObject *)object animation:(UIViewAnimationTransition)animation {
-    [self showObject:object withSelector:[self defaultInitializer] animation:animation duration:PILOT_ANIMATION_DURATION asModal:YES];
-}
-
-+ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector animation:(UIViewAnimationTransition)animation duration:(CGFloat)duration {
-    [self showObject:object withSelector:selector animation:animation duration:duration asModal:NO];
-}
-
-+ (void)showObjectAsModal:(NSManagedObject *)object withSelector:(SEL)selector animation:(UIViewAnimationTransition)animation {
-    [self showObject:object withSelector:selector animation:animation duration:PILOT_ANIMATION_DURATION asModal:YES];
-}
-
-+ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector animation:(UIViewAnimationTransition)animation duration:(CGFloat)duration asModal:(BOOL)asModal {
++ (void)showObject:(NSManagedObject *)object withSelector:(SEL)selector animated:(BOOL)animated asModal:(BOOL)asModal {
     Class viewControllerClass = [self viewControllerClassForObject:object];
     
     NSAssert([viewControllerClass instancesRespondToSelector:selector], @"PILOT ERROR: Could not find selector %@ for %@ViewController", 
@@ -140,9 +142,9 @@ static UITabBarController *rootTabBarController = nil;
     id viewController = [[[viewControllerClass alloc] performSelector:selector withObject:object.objectID.URIRepresentation] autorelease];
     
     if (asModal) {
-        [self presentViewControllerAsModal:viewController withAnimation:animation];
+        [self presentViewControllerAsModal:viewController animated:animated];
     } else {
-        [self presentViewController:viewController withAnimation:animation andDuration:duration];
+        [self pushViewController:viewController animated:animated];
     }
 }
 

--- a/PilotTestApp/Classes/PTTestViewController.m
+++ b/PilotTestApp/Classes/PTTestViewController.m
@@ -71,7 +71,7 @@
     
     // Red
     UIButton *redButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    [redButton setTitle:@"Show Red" forState:UIControlStateNormal];
+    [redButton setTitle:@"Show Red w/o Animation" forState:UIControlStateNormal];
     [redButton addTarget:self action:@selector(redButtonAction) forControlEvents:UIControlEventTouchUpInside];
     [redButton sizeToFit];
     [self.view addSubview:redButton];
@@ -90,10 +90,22 @@
     [blueButton sizeToFit];
     [self.view addSubview:blueButton];
     
+    // Pop
+    UIButton *popButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+    [popButton setTitle:@"Pop" forState:UIControlStateNormal];
+    [popButton addTarget:self action:@selector(popButtonAction) forControlEvents:UIControlEventTouchUpInside];
+    [popButton sizeToFit];
+    [self.view addSubview:popButton];
+    
+    // Pop Animated
+    UIButton *popAnimatedButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+    [popAnimatedButton setTitle:@"Pop Animated" forState:UIControlStateNormal];
+    [popAnimatedButton addTarget:self action:@selector(popAnimatedButtonAction) forControlEvents:UIControlEventTouchUpInside];
+    [popAnimatedButton sizeToFit];
+    [self.view addSubview:popAnimatedButton];
+    
     // This is just a convience function to layout the title and buttons
     [self layoutViews];
-
-    
 }
 
 - (void)viewDidUnload {
@@ -106,7 +118,7 @@
 
 - (void)redButtonAction {
     RedObject *newRedObject = [RedObject objectWithUniqueMessage];
-    [Pilot showObject:newRedObject animation:UIViewAnimationOptionTransitionCurlDown duration:0.8];
+    [Pilot showObject:newRedObject animated:NO];
 }
 
 - (void)greenButtonAction {
@@ -119,6 +131,14 @@
     [Pilot showObject:newBlueObject];
 }
 
+- (void)popButtonAction {
+    [Pilot popTopViewControllerAnimated:NO];
+}
+
+- (void)popAnimatedButtonAction {
+    [Pilot popTopViewControllerAnimated:YES];
+}
+
 #pragma - Layout
 
 - (void)layoutViews {
@@ -127,7 +147,7 @@
         
         if (i == 0) {
             v.frame = CGRectMake(round(self.view.frame.size.width / 2 - v.frame.size.width / 2), 
-                                 round(v.frame.size.height + 20), 
+                                 round(v.frame.size.height + 10), 
                                  v.frame.size.width, 
                                  v.frame.size.height);
         } else {
@@ -135,7 +155,7 @@
             UIView *v0 = [self.view.subviews objectAtIndex:(i - 1)];
             
             v.frame = CGRectMake(round(self.view.frame.size.width / 2 - v.frame.size.width / 2), 
-                                 round(v0.frame.origin.y + v0.frame.size.height + 20), 
+                                 round(v0.frame.origin.y + v0.frame.size.height + 10), 
                                  v.frame.size.width, 
                                  v.frame.size.height);
         }


### PR DESCRIPTION
The support for custom animation wasn't really there, and if you passed the "None" animation option, it still animated.  I did all this on master, and figured a pull request was fitting, since you probably don't want your stuff to change underneath you!

Like we discussed, Pilot is now more like your app wide nav controller.  You can push/pop view controllers outside of the show model workflow, which I have had to use.  I was using custom animations, but now I'm not, so I just pulled that out.

-Andrew
